### PR TITLE
fix: int/float enum client generation

### DIFF
--- a/generators/client/client_generator_test.go
+++ b/generators/client/client_generator_test.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -23,4 +25,36 @@ func TestOpenAPIGenerator(t *testing.T) {
 func TestToColonPath(t *testing.T) {
 	NewWithT(t).Expect(toColonPath("/user/{userID}/tags/{tagID}")).To(Equal("/user/:userID/tags/:tagID"))
 	NewWithT(t).Expect(toColonPath("/user/{userID}")).To(Equal("/user/:userID"))
+}
+
+func TestGenEnumIntClient(t *testing.T) {
+	cwd, _ := os.Getwd()
+	g := NewClientGenerator("demo", &url.URL{}, OptionVendorImportByGoMod())
+	snippet := []byte(`
+{
+  "openapi": "3.0.3",
+  "components": {
+    "schemas": {
+      "ExampleComCloudchainSrvDemoPkgConstantsErrorsStatusError": {
+        "type": "integer",
+        "format": "int32",
+        "enum": [
+          400000001,
+          400000002
+        ],
+        "x-enum-labels": [
+          "400000001",
+          "400000002"
+        ],
+        "x-go-vendor-type": "example.com/cloudchain/srv-demo/pkg/constants/errors.StatusError",
+        "x-id": "ExampleComCloudchainSrvDemoPkgConstantsErrorsStatusError"
+      }
+    }
+  }
+}
+`)
+	if err := json.NewDecoder(bytes.NewBuffer(snippet)).Decode(g.openAPI); err != nil {
+		panic(err)
+	}
+	g.Output(filepath.Join(cwd, "../../testdata/enum"))
 }

--- a/generators/client/client_generator_test.go
+++ b/generators/client/client_generator_test.go
@@ -27,7 +27,7 @@ func TestToColonPath(t *testing.T) {
 	NewWithT(t).Expect(toColonPath("/user/{userID}")).To(Equal("/user/:userID"))
 }
 
-func TestGenEnumIntClient(t *testing.T) {
+func TestGenEnumInt(t *testing.T) {
 	cwd, _ := os.Getwd()
 	g := NewClientGenerator("demo", &url.URL{}, OptionVendorImportByGoMod())
 	snippet := []byte(`
@@ -45,6 +45,38 @@ func TestGenEnumIntClient(t *testing.T) {
         "x-enum-labels": [
           "400000001",
           "400000002"
+        ],
+        "x-go-vendor-type": "example.com/cloudchain/srv-demo/pkg/constants/errors.StatusError",
+        "x-id": "ExampleComCloudchainSrvDemoPkgConstantsErrorsStatusError"
+      }
+    }
+  }
+}
+`)
+	if err := json.NewDecoder(bytes.NewBuffer(snippet)).Decode(g.openAPI); err != nil {
+		panic(err)
+	}
+	g.Output(filepath.Join(cwd, "../../testdata/enum"))
+}
+
+func TestGenEnumFloat(t *testing.T) {
+	cwd, _ := os.Getwd()
+	g := NewClientGenerator("demo", &url.URL{}, OptionVendorImportByGoMod())
+	snippet := []byte(`
+{
+  "openapi": "3.0.3",
+  "components": {
+    "schemas": {
+      "ExampleComCloudchainSrvDemoPkgConstantsErrorsStatusError": {
+        "type": "number",
+        "format": "double",
+        "enum": [
+          40000000.1,
+          40000000.2
+        ],
+        "x-enum-labels": [
+          "40000000.1",
+          "40000000.2"
         ],
         "x-go-vendor-type": "example.com/cloudchain/srv-demo/pkg/constants/errors.StatusError",
         "x-id": "ExampleComCloudchainSrvDemoPkgConstantsErrorsStatusError"

--- a/generators/client/type_generator.go
+++ b/generators/client/type_generator.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"math"
 	"path/filepath"
 	"strconv"
 
@@ -165,9 +166,12 @@ func (g *TypeGenerator) TypeIndirect(ctx context.Context, schema *oas.Schema) (c
 
 				switch v := e.(type) {
 				case float64:
-					o.Float = &v
-				case int64:
-					o.Int = &v
+					if math.Floor(v) == v {
+						vi := int64(v)
+						o.Int = &vi
+					} else {
+						o.Float = &v
+					}
 				case string:
 					o.Str = &v
 				}

--- a/generators/client/type_generator.go
+++ b/generators/client/type_generator.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"math"
 	"path/filepath"
-	"strconv"
-
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/go-courier/codegen"
@@ -402,6 +401,9 @@ const (
 		switch n := v.(type) {
 		case string:
 			value = strconv.Quote(n)
+		case float64:
+			vf := v.(float64)
+			v = strings.Replace(strconv.FormatFloat(vf, 'f', -1, 64), ".", "_", 1)
 		}
 
 		_, _ = fmt.Fprintf(file, `%s__%v %s = %v // %s


### PR DESCRIPTION
https://github.com/go-courier/httptransport/blob/b694175dd2696874b33d2f30c997cca87797871f/generators/client/type_generator.go#L163-L180

branch int64 will never be reached, because json number is treated as float64, by default

float64 will generate something like:

> SOME_STATUS_ERROR__4.00000001e+08 SomeStatusError = 4.00000001e+08 // 400000001

lead generation to failure
